### PR TITLE
feat: make service descriptions accessible

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,36 +201,60 @@
 
             <h2>Services</h2>
             <div class="services">
-                <div class="service">
-                    <i class="fas fa-code"></i>
-                    <h3>Software Development</h3>
-                    <div class="service-description">From desktop applications to cloud-based solutions, I specialize in developing software that meets the specific needs of your business. Whether it’s custom software, enterprise applications, or web-based solutions, I leverage my skills to deliver efficient, scalable, and maintainable software.</div>
-                </div>
-                <div class="service">
-                    <i class="fas fa-globe"></i>
-                    <h3>Web3</h3>
-                    <div class="service-description">I specialize in Web3 development, focusing on building decentralized applications (dApps) that leverage blockchain technology. From smart contract development to integrating blockchain into your existing systems, I offer services that help you tap into the next generation of the internet.</div>
-                </div>
-                <div class="service">
-                    <i class="fas fa-laptop-code"></i>
-                    <h3>Web Application Development</h3>
-                    <div class="service-description">I offer comprehensive web application development services, including frontend and backend development, responsive design, and performance optimization. My focus is on creating user-friendly, scalable, and secure applications.</div>
-                </div>
-                <div class="service">
-                    <i class="fas fa-mobile-alt"></i>
-                    <h3>Mobile Application Development</h3>
-                    <div class="service-description">I provide mobile application development services for both Android and iOS platforms, utilizing cross-platform frameworks like React Native to ensure consistent performance and user experience across devices.</div>
-                </div>
-                <div class="service">
-                    <i class="fas fa-paint-brush"></i>
-                    <h3>Front End Development</h3>
-                    <div class="service-description">Front-end development services focus on creating visually appealing and interactive user interfaces. I use modern technologies like HTML, CSS, JavaScript, and React to build responsive and accessible websites that provide an excellent user experience.</div>
-                </div>
-                <div class="service">
-                    <i class="fas fa-server"></i>
-                    <h3>Back End Development</h3>
-                    <div class="service-description">My backend development services include creating robust APIs, integrating databases, and ensuring secure and efficient data handling. I utilize technologies like Node.js, Express, MySQL, and MongoDB to build scalable backend systems.</div>
-                </div>
+                <article class="service">
+                    <h3>
+                        <button class="service-toggle" aria-expanded="false" aria-controls="service1-desc">
+                            <i class="fas fa-code" aria-hidden="true"></i>
+                            <span class="service-title">Software Development</span>
+                        </button>
+                    </h3>
+                    <div id="service1-desc" class="service-description">From desktop applications to cloud-based solutions, I specialize in developing software that meets the specific needs of your business. Whether it’s custom software, enterprise applications, or web-based solutions, I leverage my skills to deliver efficient, scalable, and maintainable software.</div>
+                </article>
+                <article class="service">
+                    <h3>
+                        <button class="service-toggle" aria-expanded="false" aria-controls="service2-desc">
+                            <i class="fas fa-globe" aria-hidden="true"></i>
+                            <span class="service-title">Web3</span>
+                        </button>
+                    </h3>
+                    <div id="service2-desc" class="service-description">I specialize in Web3 development, focusing on building decentralized applications (dApps) that leverage blockchain technology. From smart contract development to integrating blockchain into your existing systems, I offer services that help you tap into the next generation of the internet.</div>
+                </article>
+                <article class="service">
+                    <h3>
+                        <button class="service-toggle" aria-expanded="false" aria-controls="service3-desc">
+                            <i class="fas fa-laptop-code" aria-hidden="true"></i>
+                            <span class="service-title">Web Application Development</span>
+                        </button>
+                    </h3>
+                    <div id="service3-desc" class="service-description">I offer comprehensive web application development services, including frontend and backend development, responsive design, and performance optimization. My focus is on creating user-friendly, scalable, and secure applications.</div>
+                </article>
+                <article class="service">
+                    <h3>
+                        <button class="service-toggle" aria-expanded="false" aria-controls="service4-desc">
+                            <i class="fas fa-mobile-alt" aria-hidden="true"></i>
+                            <span class="service-title">Mobile Application Development</span>
+                        </button>
+                    </h3>
+                    <div id="service4-desc" class="service-description">I provide mobile application development services for both Android and iOS platforms, utilizing cross-platform frameworks like React Native to ensure consistent performance and user experience across devices.</div>
+                </article>
+                <article class="service">
+                    <h3>
+                        <button class="service-toggle" aria-expanded="false" aria-controls="service5-desc">
+                            <i class="fas fa-paint-brush" aria-hidden="true"></i>
+                            <span class="service-title">Front End Development</span>
+                        </button>
+                    </h3>
+                    <div id="service5-desc" class="service-description">Front-end development services focus on creating visually appealing and interactive user interfaces. I use modern technologies like HTML, CSS, JavaScript, and React to build responsive and accessible websites that provide an excellent user experience.</div>
+                </article>
+                <article class="service">
+                    <h3>
+                        <button class="service-toggle" aria-expanded="false" aria-controls="service6-desc">
+                            <i class="fas fa-server" aria-hidden="true"></i>
+                            <span class="service-title">Back End Development</span>
+                        </button>
+                    </h3>
+                    <div id="service6-desc" class="service-description">My backend development services include creating robust APIs, integrating databases, and ensuring secure and efficient data handling. I utilize technologies like Node.js, Express, MySQL, and MongoDB to build scalable backend systems.</div>
+                </article>
             </div>
 
         </section>

--- a/script.js
+++ b/script.js
@@ -135,18 +135,15 @@ document.addEventListener("DOMContentLoaded", () => {
     window.addEventListener('scroll', highlightNav);
     highlightNav();
 
-    // Auto-expand services on scroll
-    const serviceElements = document.querySelectorAll('.service');
-    const serviceObserver = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                entry.target.classList.add('expanded');
-            } else {
-                entry.target.classList.remove('expanded');
-            }
+    // Toggle service descriptions
+    const serviceButtons = document.querySelectorAll('.service-toggle');
+    serviceButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const service = button.closest('.service');
+            const expanded = service.classList.toggle('expanded');
+            button.setAttribute('aria-expanded', expanded);
         });
-    }, { threshold: 0.5 });
-    serviceElements.forEach(service => serviceObserver.observe(service));
+    });
 
     // Contact form submission
     const form = document.getElementById('contactForm');

--- a/style.css
+++ b/style.css
@@ -221,6 +221,19 @@ section {
     justify-content: center;
 }
 
+.service-toggle {
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    padding: 0;
+}
+
 .service i {
     font-size: 3rem;
     margin-bottom: 0.5rem;
@@ -246,13 +259,6 @@ section {
 
 .service:hover {
     transform: scale(1.1); /* Slightly enlarge the service box */
-}
-
-.service:hover .service-description {
-    display: block;
-    width: 100%;
-    height: auto;
-    padding-top: 0.5rem;
 }
 
 .service.expanded {


### PR DESCRIPTION
## Summary
- wrap each service offering in an article with a toggle button and aria-expanded
- add JS to synchronize aria-expanded with the expanded class
- style new service-toggle buttons and rely on expanded state for showing descriptions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689570e037848321afb11ddf328761f0