### PR TITLE
Use graffiti font for headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://fonts.googleapis.com/css2?family=Rubik+Puddles&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3.6.2/dist/email.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -9,6 +9,11 @@ body {
     text-align: center; /* Center all text */
 }
 
+/* Graffiti style for headings */
+h1, h2, h3, h4, h5, h6, .service-title {
+    font-family: 'Rubik Puddles', cursive;
+}
+
 header {
     background-color: #333;
     padding: 1rem 0;


### PR DESCRIPTION
## Summary
- Load Google Fonts' **Rubik Puddles** font for a graffiti-inspired look
- Apply the drippy graffiti font to all heading elements and service titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ec920dfc832183ae411c0e53ad94