### PR TITLE
feat: apply spray-paint graffiti text style

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="https://fonts.googleapis.com/css2?family=Rubik+Puddles&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Rubik+Wet+Paint&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3.6.2/dist/email.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -9,9 +9,13 @@ body {
     text-align: center; /* Center all text */
 }
 
-/* Graffiti style for headings */
-h1, h2, h3, h4, h5, h6, .service-title {
-    font-family: 'Rubik Puddles', cursive;
+/* Graffiti spray paint style for headings and navigation */
+h1, h2, h3, h4, h5, h6, .service-title, header nav ul li a {
+    font-family: 'Rubik Wet Paint', cursive;
+    text-shadow:
+        0 2px 2px rgba(0, 0, 0, 0.8),
+        0 5px 5px rgba(0, 0, 0, 0.6),
+        0 8px 8px rgba(0, 0, 0, 0.4);
 }
 
 header {


### PR DESCRIPTION
## Summary
- swap bubbly font for `Rubik Wet Paint` and apply to all headings
- give navigation links the same spray-paint font and drippy shadows

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ef194d888321a44ca1f21afa28f1