### PR TITLE
Use drippy spray paint font for headings and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="https://fonts.googleapis.com/css2?family=Rubik+Wet+Paint&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Nosifer&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3.6.2/dist/email.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -11,11 +11,10 @@ body {
 
 /* Graffiti spray paint style for headings and navigation */
 h1, h2, h3, h4, h5, h6, .service-title, header nav ul li a {
-    font-family: 'Rubik Wet Paint', cursive;
+    font-family: 'Nosifer', cursive;
     text-shadow:
-        0 2px 2px rgba(0, 0, 0, 0.8),
-        0 5px 5px rgba(0, 0, 0, 0.6),
-        0 8px 8px rgba(0, 0, 0, 0.4);
+        0 0 5px rgba(0, 0, 0, 0.8),
+        0 0 10px rgba(0, 0, 0, 0.6);
 }
 
 header {


### PR DESCRIPTION
## Summary
- Replace elegant typeface with spray paint-style Nosifer font
- Apply drippy text shadow for navigation links, headings and service titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f0cf677883218f1501d3f40f6d5a