### PR TITLE
Shrink nav graffiti text to single line

### DIFF
--- a/style.css
+++ b/style.css
@@ -72,7 +72,8 @@ header nav ul li a {
     text-decoration: none;
     font-weight: bold;
     transition: color 0.3s ease;
-    font-size: 0.9rem;
+    font-size: 0.6rem;
+    white-space: nowrap;
 }
 
 header nav ul li a.active, header nav ul li a:hover {


### PR DESCRIPTION
## Summary
- Reduce graffiti-style navigation link font to 0.6rem
- Prevent menu links from wrapping onto multiple lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b305d9697c8321a215ad50d5b70202