### PR TITLE
style: reduce text sizes for education and projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,12 +126,12 @@
             <br>
             
             <h2>Education</h2>
-            <h3><a href="https://www.parchment.com/u/award/bb4099bcde05be95743325a919f1f578" target="_blank">Associate in General Studies</a></h3>
-            <h3><a href="https://www.parchment.com/u/award/7cdde7d52ef1491f01f34938ec6e4b13" target="_blank">Associate of Science - AS in Software Development</a></h3>
-            <h3><a href="https://www.parchment.com/u/award/57cf022f3e8e77983ef0eae25a55b733" target="_blank">Advanced Certificate in Software Development</a></h3>
-            <h3><a href="https://www.parchment.com/u/award/54d14e9d77d3669e6c1b099e69dd68fb" target="_blank">Basic Certificate in Web Development</a></h3>
-            <h3><a href="https://www.parchment.com/u/award/57cf022f3e8e77983ef0eae25a55b733" target="_blank">HarvardX CS50x Intro to Computer Science</a></h3>
-            <h3><a href="https://www.parchment.com/u/award/57cf022f3e8e77983ef0eae25a55b733" target="_blank">HarvardX CS50x Intro to Artificial Intelligence with Python</a></h3>
+            <p class="education-item"><a href="https://www.parchment.com/u/award/bb4099bcde05be95743325a919f1f578" target="_blank">Associate in General Studies</a></p>
+            <p class="education-item"><a href="https://www.parchment.com/u/award/7cdde7d52ef1491f01f34938ec6e4b13" target="_blank">Associate of Science - AS in Software Development</a></p>
+            <p class="education-item"><a href="https://www.parchment.com/u/award/57cf022f3e8e77983ef0eae25a55b733" target="_blank">Advanced Certificate in Software Development</a></p>
+            <p class="education-item"><a href="https://www.parchment.com/u/award/54d14e9d77d3669e6c1b099e69dd68fb" target="_blank">Basic Certificate in Web Development</a></p>
+            <p class="education-item"><a href="https://www.parchment.com/u/award/57cf022f3e8e77983ef0eae25a55b733" target="_blank">HarvardX CS50x Intro to Computer Science</a></p>
+            <p class="education-item"><a href="https://www.parchment.com/u/award/57cf022f3e8e77983ef0eae25a55b733" target="_blank">HarvardX CS50x Intro to Artificial Intelligence with Python</a></p>
         
         <br>
         <br>

--- a/style.css
+++ b/style.css
@@ -182,6 +182,18 @@ section {
     font-weight: bold;
 }
 
+.education-item {
+    font-family: 'Roboto', sans-serif;
+    font-size: 0.8rem;
+    font-weight: normal;
+    margin: 0.2rem 0;
+}
+
+.education-item a {
+    color: white;
+    text-decoration: none;
+}
+
 .projects {
     display: flex;
     flex-wrap: wrap;
@@ -202,6 +214,10 @@ section {
     justify-content: center; /* Center content vertically */
     align-items: center; /* Center content horizontally */
     min-height: 200px; /* Optional: Ensure a minimum height */
+}
+
+.project h2 {
+    font-size: 1rem;
 }
 
 .project .description {


### PR DESCRIPTION
## Summary
- shrink education items and display them in regular text style
- reduce featured project domain-name headers for a subtler look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b30acdeed88321b175091c9312f184