### PR TITLE
Style education links

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
             <br>
             
             <h2>Education</h2>
-            <p class="education-item"><a href="https://www.parchment.com/u/award/bb4099bcde05be95743325a919f1f578" target="_blank">Associate in General Studies</a></p>
+            <p class="education-item"><a href="https://www.parchment.com/u/award/bb4099bcde05be95743325a919f1f578" target="_blank"><i class="fas fa-hand-pointer"></i> Associate in General Studies</a></p>
             <p class="education-item"><a href="https://www.parchment.com/u/award/7cdde7d52ef1491f01f34938ec6e4b13" target="_blank">Associate of Science - AS in Software Development</a></p>
             <p class="education-item"><a href="https://www.parchment.com/u/award/57cf022f3e8e77983ef0eae25a55b733" target="_blank">Advanced Certificate in Software Development</a></p>
             <p class="education-item"><a href="https://www.parchment.com/u/award/54d14e9d77d3669e6c1b099e69dd68fb" target="_blank">Basic Certificate in Web Development</a></p>

--- a/style.css
+++ b/style.css
@@ -193,14 +193,18 @@ section {
 
 .education-item {
     font-family: 'Roboto', sans-serif;
-    font-size: 0.8rem;
-    font-weight: normal;
+    font-size: 1.6rem;
+    font-weight: bold;
     margin: 0.2rem 0;
 }
 
 .education-item a {
     color: white;
-    text-decoration: none;
+    text-decoration: underline;
+}
+
+.education-item i {
+    margin-right: 0.5rem;
 }
 
 .projects {


### PR DESCRIPTION
## Summary
- double the size of education links with bold and underlined styling
- add hand-pointer icon to first education link to indicate clickability

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c2f94e0c832180bfa5c7c0ea7970