### PR TITLE
Add headshot placeholder and animate intro text

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
     <main>
         <section id="home" class="intro">
             <h1 id="line1"></h1>
+            <div class="headshot-container">
+                <img src="headshot.png" alt="Headshot" class="headshot">
+            </div>
             <h1 id="line2"></h1>
             <h2 id="intro-text-line3"></h2>
             <h2 id="intro-text-line4"></h2>

--- a/script.js
+++ b/script.js
@@ -35,6 +35,15 @@ document.addEventListener("DOMContentLoaded", () => {
             setTimeout(typeLine2, 100); // Adjust typing speed here
         } else {
             currentCharIndex = 0;
+            setTimeout(deleteLine2, 500); // Pause before deleting line 2
+        }
+    }
+
+    function deleteLine2() {
+        if (line2Element.innerHTML.length > 0) {
+            line2Element.innerHTML = line2Element.innerHTML.substring(0, line2Element.innerHTML.length - 1);
+            setTimeout(deleteLine2, 50); // Adjust deleting speed here
+        } else {
             setTimeout(typeJobTitle, 500); // Pause before typing job titles
         }
     }

--- a/style.css
+++ b/style.css
@@ -107,6 +107,20 @@ section {
     margin-top: 1rem; /* Add margin top */
 }
 
+.headshot-container {
+    margin: 1rem 0;
+}
+
+.headshot {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    border: 2px solid white;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.8),
+                0 0 10px rgba(0, 0, 0, 0.6);
+    object-fit: cover;
+}
+
 .more-projects {
     display: none;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Add headshot placeholder above name in intro section
- Style headshot with circular white border and black glow
- Animate clearing of name before displaying job titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6e0ed890832181608529bfa1d7cd