### PR TITLE
Update hero portrait layout and social placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,13 +56,6 @@
                         <div class="meta-chip"><img src="https://api.iconify.design/lucide/shield-check.svg?color=%23e6edf3" class="icon-img" alt="Shield icon"> Secure by design</div>
                         <div class="meta-chip"><img src="https://api.iconify.design/lucide/clock-3.svg?color=%23e6edf3" class="icon-img" alt="Clock icon"> Rapid delivery</div>
                     </div>
-                    <div class="social-row">
-                        <a href="https://github.com/marcoromanodev" aria-label="GitHub" target="_blank"><img src="https://api.iconify.design/mdi/github.svg?color=%23e6edf3" class="icon-img" alt="GitHub"></a>
-                        <a href="https://www.linkedin.com/in/marcoromanojr" aria-label="LinkedIn" target="_blank"><img src="https://api.iconify.design/mdi/linkedin.svg?color=%23e6edf3" class="icon-img" alt="LinkedIn"></a>
-                        <a href="https://x.com/MarcoRomanoJr" aria-label="X" target="_blank"><img src="logos/xlogo.png" class="icon-img" alt="X"></a>
-                        <a href="https://www.instagram.com/MarcoRomanoJr" aria-label="Instagram" target="_blank"><img src="https://api.iconify.design/mdi/instagram.svg?color=%23e6edf3" class="icon-img" alt="Instagram"></a>
-                        <a href="https://stackoverflow.com/users/27101244/marcoromanodev" aria-label="Stack Overflow" target="_blank"><img src="https://api.iconify.design/mdi/stack-overflow.svg?color=%23e6edf3" class="icon-img" alt="Stack Overflow"></a>
-                    </div>
                 </div>
                 <div class="hero-visual">
                     <div class="glass-card">
@@ -75,6 +68,13 @@
                             <span class="pill">Web3</span>
                             <span class="pill">Full-stack</span>
                             <span class="pill">Product-minded</span>
+                        </div>
+                        <div class="social-row">
+                            <a href="https://github.com/marcoromanodev" aria-label="GitHub" target="_blank"><img src="https://api.iconify.design/mdi/github.svg?color=%23e6edf3" class="icon-img" alt="GitHub"></a>
+                            <a href="https://www.linkedin.com/in/marcoromanojr" aria-label="LinkedIn" target="_blank"><img src="https://api.iconify.design/mdi/linkedin.svg?color=%23e6edf3" class="icon-img" alt="LinkedIn"></a>
+                            <a href="https://x.com/MarcoRomanoJr" aria-label="X" target="_blank"><img src="logos/xlogo.png" class="icon-img" alt="X"></a>
+                            <a href="https://www.instagram.com/MarcoRomanoJr" aria-label="Instagram" target="_blank"><img src="https://api.iconify.design/mdi/instagram.svg?color=%23e6edf3" class="icon-img" alt="Instagram"></a>
+                            <a href="https://stackoverflow.com/users/27101244/marcoromanodev" aria-label="Stack Overflow" target="_blank"><img src="https://api.iconify.design/mdi/stack-overflow.svg?color=%23e6edf3" class="icon-img" alt="Stack Overflow"></a>
                         </div>
                     </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -252,6 +252,8 @@ img {
     display: flex;
     align-items: center;
     gap: 0.85rem;
+    justify-content: center;
+    margin-top: 0.8rem;
 }
 
 .social-row a {
@@ -281,11 +283,16 @@ img {
     background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
     border: 1px solid var(--border);
     border-radius: 20px;
-    padding: 1.2rem;
+    padding: 1.4rem 1.2rem;
     box-shadow: var(--shadow);
     width: min(360px, 100%);
     position: relative;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+    text-align: center;
 }
 
 .glass-card::after {
@@ -301,18 +308,20 @@ img {
 }
 
 .headshot-modern {
-    width: 100%;
-    border-radius: 16px;
+    width: clamp(180px, 60vw, 230px);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
     position: relative;
     z-index: 1;
     border: 1px solid rgba(255, 255, 255, 0.15);
+    object-fit: cover;
 }
 
 .status {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    margin-top: 1rem;
+    margin-top: 0.4rem;
     padding: 0.55rem 0.9rem;
     border-radius: 12px;
     background: rgba(255, 179, 71, 0.12);
@@ -369,9 +378,10 @@ img {
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
-    margin-top: 1rem;
+    margin-top: 0.6rem;
     position: relative;
     z-index: 1;
+    justify-content: center;
 }
 
 .pill {


### PR DESCRIPTION
## Summary
- reshape hero headshot into a centered circular portrait
- move social links under the hero portrait beneath the status and skill pills
- refine glass card spacing to keep content aligned around the updated layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69434aad1c5483219d14f2677dbb430e)